### PR TITLE
Fix SDL examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 if(PSP)
     target_link_libraries(${PROJECT_NAME} PRIVATE
         SDL2_mixer
+        SDL2
         vorbisfile
         vorbis
         ogg
@@ -1149,10 +1150,10 @@ if(PSP)
     target_link_libraries(${PROJECT_NAME} PRIVATE
         SDL2_ttf
         freetype
-        m 
-        z 
+        m
         bz2
         png16
+        z
     )
     create_pbp_file(
         TARGET ${PROJECT_NAME}


### PR DESCRIPTION
This PR solves two compiling errors by adding / arranging the linked libraries on the sample CMake files.
Note: I'm using the pspdev SDK downloaded from https://github.com/pspdev/pspdev/releases/tag/latest

When following the SDL2 examples, I tried to compile and found linking issues with the Mixer and TTF examples.
For example:

```
[ 50%] Linking C executable sdl2_mixer
/usr/local/pspdev/bin/../lib/gcc/psp/11.2.0/../../../../psp/bin/ld: /usr/local/pspdev/psp/lib/libSDL2_mixer.a(mixer.c.obj): in function `Mix_LoadWAV_RW':
(.text+0x6c4): undefined reference to `SDL_LoadWAV_RW'
/usr/local/pspdev/bin/../lib/gcc/psp/11.2.0/../../../../psp/bin/ld: /usr/local/pspdev/psp/lib/libSDL2_mixer.a(music.c.obj): in function `Mix_EachSoundFont':
(.text+0x2c20): undefined reference to `SDL_strtokr'
```
