### PR TITLE
fix sdl2_ttf build

### DIFF
--- a/_includes/samples/sdl2_ttf/CMakeLists.txt
+++ b/_includes/samples/sdl2_ttf/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME} PRIVATE
     ${SDL2_LIBRARIES}
     ${SDL2_TTF_LIBRARIES}
+    stdc++
 )
 
 if(PSP)


### PR DESCRIPTION
This is the fix for building sdl2_ttf sample

issue log:

```sh
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/diamant3/Documents/GitHub/pspdev.github.io/_includes/samples/sdl2_ttf/build
[ 50%] Linking C executable sdl2_ttf
/usr/local/pspdev/lib/gcc/psp/13.2.0/../../../../psp/bin/ld: /usr/local/pspdev/psp/lib/libharfbuzz.a(harfbuzz.cc.obj):(.sdata.DW.ref.__gxx_personality_v0[DW.ref.__gxx_personality_v0]+0x0): undefined reference to `__gxx_personality_v0'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/sdl2_ttf.dir/build.make:97: sdl2_ttf] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/sdl2_ttf.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```