### PR TITLE
Fix download links

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -7,6 +7,10 @@ nav_order: 6
 # Downloads
 {: .fs-8 .fw-700 .text-center }
 
-Downloading the latest version of the PSPDEV toolchain for your system [here](https://github.com/pspdev/pspdev/releases/tag/latest).
+Downloading the latest version of the PSPDEV toolchain for your system:
 
-Alternatively, a Docker container is available [here](https://hub.docker.com/r/pspdev/pspdev).
+- [Windows/Ubuntu/Debian](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz)
+- [MacOS (arm64)](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-latest-arm64.tar.gz)
+- [MacOS (x86_64)](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-13-x86_64.tar.gz)
+- [Fedora](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-fedora-latest.tar.gz)
+- [Docker](https://hub.docker.com/r/pspdev/pspdev)

--- a/quickstart.md
+++ b/quickstart.md
@@ -66,7 +66,7 @@ Install the docker using the guide [the official guide](https://docs.docker.com/
 ### Toolchain 
 {: .fs-6 .fw-700 }
 
-To install the PSPDEV toolchain, first [download the latest version](https://github.com/pspdev/pspdev/releases/tag/latest) for your system. Extract it into your user's home directory, which would be `\\wsl$\home\username` on Windows, otherwise `~`. If you're on Windows, pick the Ubuntu build.
+To install the PSPDEV toolchain, first [download the latest version](downloads.html) for your system. Extract it into your user's home directory, which would be `\\wsl$\home\username` on Windows, otherwise `~`. If you're on Windows, pick the Ubuntu build.
 
 Now set the required environment variables. On Mac edit the ``~/.zprofile`` on Linux/WSL the ``~/.bashrc`` file. Add the following at the bottom:
 


### PR DESCRIPTION
Right now we link to a release on GitHub. I think it's nicer to just link to the files directly. These links will always link to the latest release build, not the development build.