### PR TITLE
Clarify to use docker for unsupported systems

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -13,4 +13,5 @@ Pick the installation guide for your system:
 - [MacOS](installation/macos.html)
 - [Ubuntu/Debian](installation/ubuntu.html)
 - [Fedora](installation/fedora.html)
-- [Docker](installation/docker.html)
+
+If your operating system is not listed above, use the [Docker installation guide](installation/docker.html).


### PR DESCRIPTION
This feels a bit better. I wasn't sure if we should add a link to the building from source as well at some point.