### PR TITLE
Add link to page source to nav footer

### DIFF
--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+Source for this site can be found <a href="https://github.com/pspdev/pspdev.github.io">here</a>. The theme used is <a href="https://github.com/just-the-docs/just-the-docs">Just the Docs</a>.
+</footer>


### PR DESCRIPTION
This leaves the link to Just the Docs, which makes us still comply with the license of that theme.