### PR TITLE
Remove link to psplink documentation

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -14,8 +14,6 @@ links to the documentation available for them:
    developer kit.
  - [PSP Allegrex documentation](https://pspdev.github.io/vfpu-docs/):
    Non-official documentation on the PSP CPU and VFPU.
- - [PSPLink Manual](https://pspdev.github.io/psplinkusb/psplink_manual.pdf):
-   User manual for the PSPLink debugging software.
  - [Unofficial PSP docs](https://uofw.github.io/upspd/docs/): A collection of docs
    from different authors and sources, covering more specific topics.
  - [Yet Another PSP Documentation](http://hitmen.c02.at/files/yapspd/): A very


### PR DESCRIPTION
It is no longer available and the debugging page is better anyway,