### PR TITLE
fix: comment about sprite

### DIFF
--- a/_includes/samples/sdl2_image/main.c
+++ b/_includes/samples/sdl2_image/main.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
         // Clear the screen
         SDL_RenderClear(renderer);
 
-        // Draw a red square
+        // Draw the 'grass' sprite
         SDL_RenderCopy(renderer, sprite, NULL, &sprite_rect);
 
         // Draw everything on a white background


### PR DESCRIPTION
The 'Draw a red square' comment does not fit this example because this source code shows SDL sprite usage.