### PR TITLE
More readable pad values

### DIFF
--- a/_includes/samples/controls/main.c
+++ b/_includes/samples/controls/main.c
@@ -52,8 +52,8 @@ int main(void)
         pspDebugScreenSetXY(0, 2);
         sceCtrlReadBufferPositive(&pad, 1);
 
-        printf("Analog X = %d, ", pad.Lx);
-        printf("Analog Y = %d \n", pad.Ly);
+        printf("Analog X = %3d, ", pad.Lx);
+        printf("Analog Y = %3d \n", pad.Ly);
 
         if (pad.Buttons != 0)
         {


### PR DESCRIPTION
When the SceCtrlData.Lx value changes, the length of the value can change (from 1 character to 3 characters) so the string for Ly moves to the right by one or two characters.
The SceCtrlData.Lx and Ly are `unsigned char` so the value are between 0 (one character length) and 255 (3 characters length). It's more readable by fixing the size for the value to 3 characters wide so the string to Ly does not move.