### PR TITLE
Improve headers and debugging page

### DIFF
--- a/basic_programs.md
+++ b/basic_programs.md
@@ -123,7 +123,7 @@ More libgu examples can be found <a href="https://github.com/pspdev/pspsdk/tree/
 
 </details>
 
-## Controller
+## Input
 {: .fs-6 .fw-700 }
 
 ![](images/controls.png)
@@ -377,9 +377,11 @@ Documentation for SDL2_ttf can be found <a href="https://wiki.libsdl.org/SDL2_tt
 </details>
 
 ## More Examples
+{: .fs-6 .fw-700 }
 
 More examples on how to use specific functions offered in the PSPDEV toolchain can be found [here](https://github.com/pspdev/pspsdk/tree/master/src/samples). Additional documentation on these functions can be found [here](https://pspdev.github.io/pspsdk/).
 
 ## Debugging
+{: .fs-6 .fw-700 }
 
 When making changes to the example programs listed above, you might run into errors or even crashes. To learn how to figure out what went wrong, check out the [debugging](debugging.html) page.

--- a/contributing.md
+++ b/contributing.md
@@ -10,6 +10,7 @@ nav_order: 7
 There are many ways to contribute to our efforts to make developing homebrew for the PlayStation Portable (PSP) easier for everyone. The first step would be to [join our Discord](https://discord.gg/bePrj9W) or use our [GitHub Discussions](https://github.com/pspdev/pspdev/discussions)!
 
 ## Ways to contribute
+{: .fs-6 .fw-700 }
 
 Before making any contribution, it's best to talk about what you want to do on [Discord](https://discord.gg/bePrj9W). After that, here are some places you can look to contribute:
 
@@ -21,6 +22,7 @@ Before making any contribution, it's best to talk about what you want to do on [
 Pull requests are always welcome!
 
 ## Where can I find the code?
+{: .fs-6 .fw-700 }
 
 The PSPDEV toolchain is build using quite a few different repositories which each add their own piece to the system. If you just want to build everything at once, the [pspdev repository](https://github.com/pspdev/pspdev) is the place to go.
 

--- a/debugging.md
+++ b/debugging.md
@@ -10,78 +10,48 @@ nav_order: 4
 When developing for the Playstation Portable (PSP), you may run into crashes or code that does not quite work like expected. Figuring out what is going in is called debugging. This page will cover how to do that.
 
 ## PSPLINK
+{: .fs-6 .fw-700 }
 
-PSPLINK is THE tool to use for debugging on the PSP. It is an application which allows you to run and debug programs for the PSP from your PC through USB.
+PSPLINK is THE tool to use for testing code on the PSP. It is an application which allows you to run and debug programs for the PSP from your PC through USB without requiring data to be transferred to the PSP. Setting it up for use requires different action for the PSP and the PC.
 
-### Setting up PSPLINK
-
-Each system involved in the use of PSPLINK requires a bit of setup for it to work. This includes both PSP and PC. Below are instructions for both.
-
-#### PSP
+### Setting PSPLINK up on the PSP
+{: .fs-4 .fw-700 }
 
 Download the latest version of PSPLINK for the PSP [here](https://github.com/pspdev/psplinkusb/releases/download/latest/psplink.zip) and extract it in ``ms0:/PSP/GAME`` on the PSP memory card.
 
-#### PC
+### Setting PSPLINK up on the PC
+{: .fs-4 .fw-700 }
 
-Depending on the operating system used the setup on PC is different. Follow the on below which is relevant to your system.
+Depending on the operating system used the setup on PC is different. Pick the setup guide for your system here:
 
-##### Windows
+- [Windows](psplink/windows.html)
+- [Linux](psplink/linux.html)
 
-On Windows a driver needs to be installed before PSPLINK can be used. To do this take the following steps:
-
-1. Make sure the programs `usbhostfs_pc` and `pspsh` are available in cmd. Otherwise download them [here](https://github.com/pspdev/psplinkusb/releases/download/latest/pspsh-windows.zip).
-2. Start PSPLINK on the Playstation Portable and connect it to the computer through USB.
-3. Download [Zadig](https://zadig.akeo.ie/) and start it. It will ask if you want to run it as administrator, click yes.
-4. In Zadig, click on `options` -> `List All Devices`.
-5. Select the entry `"PSP" type B` from the dropdown list.
-6. Left of driver, select the `libusb-win32` driver. Then click install.
-7. Wait for the installation to finish, then disconnect the USB cable from the PSP.
-
-Now PSPLINK can be used with Windows. See below how to do that.
-
-##### Linux
-
-With Linux PSPLINK will work without making any changes, but it will require using sudo for the `usbhostfs_pc` command. To make it work without sudo, a udev rule can be added.
-
-To make using PSPLINK without sudo create file called `/etc/udev/rules.d/50-psplink.rules` (for example with `sudo nano /etc/udev/rules.d/50-psplink.rules`) and add the following content:
-
-```
-SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="01c9", SYMLINK+="psp", MODE="0666"
-```
-
-Save this, in Nano this can be done with Ctrl+O and pressing enter. The run the following command:
-
-```
-sudo udevadm control --reload
-```
-
-Now PSPLINK can be used without sudo. See below how to do that.
+MacOS should not require any additional setup.
 
 ### Using PSPLINK
+{: .fs-4 .fw-700 }
 
 To be able to use PSPLINK with Playstation Portable homebrew, the homebrew will need to be build into an unencrypted ``.prx`` file. This can be done by running CMake like `psp-cmake -DBUILD_PRX=1 .` or if you're using a Makefile by adding `BUILD_PRX=1` to it. Then build the homebrew.
 
-In the build directory, open a terminal and run the following program:
+After having done all of the above, PSPLINK can be used using the following steps:
 
-```
-usbhostfs_pc
-```
-
-Keep this running!
-
-Then open another terminal window and run the following there:
-
-```
-pspsh
-```
-
-Now we can simply start our homebrew on the PSP by running the following command in the pspsh window:
-
-```
-./myhomebrew.prx
-```
-
-Replace myhomebrew with the name of the `.prx` file which was generated.
+1. Connect the PSP with a USB cable to the computer.
+2. Launch the PSPLINK homebrew on the PSP. The PSP is now waiting for input from the PC.
+3. In the build directory of the homebrew you wish to test, open a terminal and run the following:
+    ```sh
+    usbhostfs_pc
+    ```
+    Keep this running!
+4. Then open another terminal window and run the following there:
+    ```sh
+    pspsh
+    ```
+5. Now you can simply start our homebrew on the PSP by running the following command in the pspsh window:
+    ```sh
+    ./myhomebrew.prx
+    ```
+    Replace myhomebrew with the name of the `.prx` file which was generated. Now the PSP should be running your project!
 
 When you're done with the current build, just run `reset`, rebuild the homebrew and try again.
 
@@ -92,12 +62,13 @@ Options available can be found when using the `help` command, but here are some 
 - `poweroff` for shutting down the PSP.
 
 ### Getting Basic Crash Information
+{: .fs-4 .fw-700 }
 
 When a crash happens a crash log will be shown with a hint of what might have happened at the top and some additional info. If you wish to figure out where the crash happened, only the address is needed.
 
 To figure out where the crash happened, open another terminal in the build directory and use the address shown by PSPLINK in the following command:
 
-```
+```sh
 psp-addr2line -e myhomebrew address
 ```
 
@@ -107,15 +78,18 @@ If no result is returned, make sure to build with the `-g` or `-g3` option and w
 
 The information received from `psp-addr2line` will be limited and not always useful, for more information you'll have to use a debugger as described below.
 
-### Using a Debugger
+## Using a Debugger
+{: .fs-6 .fw-700 }
 
-When using `psp-addr2line` is not enough to figure out what is going on, the best way to debug will be by using an actual debugger called GDB. PSPLINK allows you to enable access to `psp-gdb` which comes bundles with the PSPDEV toolchain.
+When using `psp-addr2line` is not enough to figure out what is going on, the best way to debug will be by using an actual debugger called GDB, which comes bundled with the PSPDEV toolchain as the `psp-gdb` command. PSPLINK allows this debugger to connect directly to the PSP.
 
-#### Preparation
+### Preparation
+{: .fs-4 .fw-700 }
 
 Prepare a separate terminal for `usbhostfs_pc`, `pspsh` and `psp-gdb`. Open all of them in the directory in which your compiled `.prx` and the `elf` (PSP binary) files are located.
 
-##### 1. usbhostfs_pc
+#### 1. usbhostfs_pc
+{: .fs-2 .fw-700 }
 
 Run `usbhostfs_pc` on your terminal dedicated for `usbhostfs_pc` and you will see the `waiting for device...` status. 
 
@@ -123,7 +97,8 @@ Now start the PSPLINK app on your PSP and connect the USB cable. You should see 
 
 **Do not close this terminal after that.**
 
-##### 2. pspsh
+#### 2. pspsh
+{: .fs-2 .fw-700 }
 
 Run `pspsh` on your terminal dedicated for `pspsh` and you will see the `host0:/>`. Now run `debug file.prx`, and it will display something like this:
 
@@ -136,7 +111,8 @@ host0:/> Loaded host0:/<file.prx> - UID 0x0408A763, Entry 0x088040AC
 
 It means the debugger is succesfully loaded. You can type `reset` if there's something wrong with your GDBServer.
 
-##### 3. psp-gdb
+#### 3. psp-gdb
+{: .fs-2 .fw-700 }
 
 In a new terminal run `psp-gdb file -q` and you will see something like this:
 
@@ -176,5 +152,6 @@ Here are a few useful commands for getting around in psp-gdb:
 You can type `help` for more information about the psp-gdb commands.
 
 ## Done
+{: .fs-6 .fw-700 }
 
 Now you know how to debug your code. Make sure to check out the [Tips and Tricks](tips_tricks.html) section to get most out of your PSP development experience.

--- a/installation.md
+++ b/installation.md
@@ -5,7 +5,7 @@ nav_order: 2
 ---
 
 # Installation
-{: .fs-10 .fw-700 .text-center }
+{: .fs-8 .fw-700 .text-center }
 
 Pick the installation guide for your system:
 

--- a/installation/docker.md
+++ b/installation/docker.md
@@ -5,7 +5,7 @@ nav_exclude: true
 ---
 
 # Installation on Docker
-{: .fs-10 .fw-700 .text-center }
+{: .fs-8 .fw-700 .text-center }
 
 ## Docker
 {: .fs-6 .fw-700 }

--- a/installation/fedora.md
+++ b/installation/fedora.md
@@ -5,7 +5,7 @@ nav_exclude: true
 ---
 
 # Installation on Fedora
-{: .fs-10 .fw-700 .text-center }
+{: .fs-8 .fw-700 .text-center }
 
 ## Dependencies
 {: .fs-6 .fw-700 }

--- a/installation/macos.md
+++ b/installation/macos.md
@@ -5,7 +5,7 @@ nav_exclude: true
 ---
 
 # Installation on MacOS
-{: .fs-10 .fw-700 .text-center }
+{: .fs-8 .fw-700 .text-center }
 
 ## Dependencies
 {: .fs-6 .fw-700 }

--- a/installation/ubuntu.md
+++ b/installation/ubuntu.md
@@ -5,7 +5,7 @@ nav_exclude: true
 ---
 
 # Installation on Ubuntu/Debian
-{: .fs-10 .fw-700 .text-center }
+{: .fs-8 .fw-700 .text-center }
 
 ## Dependencies
 {: .fs-6 .fw-700 }

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -5,10 +5,10 @@ nav_exclude: true
 ---
 
 # Installation on Windows
-{: .fs-10 .fw-700 .text-center }
+{: .fs-8 .fw-700 .text-center }
 
 ## Windows Subsystem for Linux (WSL)
-{: .fs-4 .fw-700 }
+{: .fs-6 .fw-700 }
 
 On Windows the PSPDEV toolchain is run on Ubuntu running on Microsoft's WSL. This is very easy to set up and will offer us the full power of Linux from a Windows machine.
 

--- a/psplink/linux.md
+++ b/psplink/linux.md
@@ -1,0 +1,24 @@
+---
+title: Setting up PSPLINK on Linux
+layout: home
+nav_exclude: true
+---
+
+# Setting up PSPLINK on Linux
+{: .fs-8 .fw-700 .text-center }
+
+With Linux PSPLINK will work without making any changes, but it will require using sudo for the `usbhostfs_pc` command. To make it work without sudo, a udev rule can be added.
+
+To make using PSPLINK without sudo create file called `/etc/udev/rules.d/50-psplink.rules` (for example with `sudo nano /etc/udev/rules.d/50-psplink.rules`) and add the following content:
+
+```
+SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="01c9", SYMLINK+="psp", MODE="0666"
+```
+
+Save this, in Nano this can be done with Ctrl+O and pressing enter. The run the following command:
+
+```
+sudo udevadm control --reload
+```
+
+Now PSPLINK can be used without sudo. Continue with the instructions on the [Debugging](../debugging.html) page.

--- a/psplink/windows.md
+++ b/psplink/windows.md
@@ -1,0 +1,20 @@
+---
+title: Setting up PSPLINK on Windows
+layout: home
+nav_exclude: true
+---
+
+# Setting up PSPLINK on Windows
+{: .fs-8 .fw-700 .text-center }
+
+On Windows a driver needs to be installed before PSPLINK can be used. To do this take the following steps:
+
+1. Make sure the programs `usbhostfs_pc` and `pspsh` are available in cmd. Otherwise download them [here](https://github.com/pspdev/psplinkusb/releases/download/latest/pspsh-windows.zip).
+2. Start PSPLINK on the Playstation Portable and connect it to the computer through USB.
+3. Download [Zadig](https://zadig.akeo.ie/) and start it. It will ask if you want to run it as administrator, click yes.
+4. In Zadig, click on `options` -> `List All Devices`.
+5. Select the entry `"PSP" type B` from the dropdown list.
+6. Left of driver, select the `libusb-win32` driver. Then click install.
+7. Wait for the installation to finish, then disconnect the USB cable from the PSP.
+
+Now PSPLINK can be used with Windows. Continue with the instructions on the [Debugging](../debugging.html) page.


### PR DESCRIPTION
I hope this is not too much for one PR. I was initially only planning to fix up the headers in the Debugging page, but then I found more that were not looking so great. I moved the instructions on setting up PSPLINK for Linux and Windows to its own pages to clean up a bit. Hope I made no errors, please do a quick check before merging.