### PR TITLE
Improve Windows installation instructions

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -48,22 +48,22 @@ Installing the PSPDEV toolchain itself can be done with the following steps:
     ```shell
     wget https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz
     ```
-3. Extract the archive using:
+2. Extract the archive using:
     ```shell
     tar -xvf pspdev-ubuntu-latest-x86_64.tar.gz
     ```
-5. To make the toolchain usable, some environment variables need to be set. The first step in doing so it to open the `~/.bashrc` file with the `nano` text editor using the following command from an Ubuntu terminal:
+3. To make the toolchain usable, some environment variables need to be set. The first step in doing so it to open the `~/.bashrc` file with the `nano` text editor using the following command from an Ubuntu terminal:
     ```shell
     nano ~/.bashrc
     ```
-5. Add the following lines at the bottom of the file in the text editor:
+4. Add the following lines at the bottom of the file in the text editor:
     ```shell
     export PSPDEV="$HOME/pspdev"
     export PATH="$PATH:$PSPDEV/bin"
     ```
-6. Now save and exit by pressing `Ctrl`+`X`, then `Y` and then enter/return.
-7. Close the current Ubuntu terminal and open a new one.
-8. From the new Ubuntu terminal, run the following command to confirm everything is set up correctly:
+5. Now save and exit by pressing `Ctrl`+`X`, then `Y` and then enter/return.
+6. Close the current Ubuntu terminal and open a new one.
+7. From the new Ubuntu terminal, run the following command to confirm everything is set up correctly:
     ```shell
     psp-config --pspdev-path
     ```

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -18,9 +18,13 @@ To set up WSL with Ubuntu in it run the following commands in a Powershell windo
 wsl --install
 ```
 
-After this is done, Ubuntu can be selected from the start menu to open a terminal. This will be used for all commands going forward.
+When this is done, restart your computer. Afterwards Ubuntu can be selected from the start menu to open a terminal, do this once to set up your user.
+
+From now on the Ubuntu shell will be used when running commands going forward.
 
 Files in Ubuntu can be accessed through a network share. In `This Computer` right click on the background and select `Map network drive`. Set the folder to `\\wsl$` to make it easily accessible.
+
+Alternatively, you can open an Ubuntu terminal in a specific directory by holding shift and clicking the right mouse button on the background in the file browser and selecting `Open Linux shell here`.
 
 ## Dependencies
 {: .fs-6 .fw-700 }
@@ -32,7 +36,7 @@ sudo apt-get update
 ```
 
 ```shell
-sudo apt-get install build-essential cmake pkgconf libreadline8 libusb-0.1 libgpgme11 libarchive-tools fakeroot curl
+sudo apt-get install build-essential cmake pkgconf libreadline8 libusb-0.1 libgpgme11 libarchive-tools fakeroot wget
 ```
 
 ## Toolchain 
@@ -40,22 +44,29 @@ sudo apt-get install build-essential cmake pkgconf libreadline8 libusb-0.1 libgp
 
 Installing the PSPDEV toolchain itself can be done with the following steps:
 
-1. In a fresh WSL Session download the Toolchain Archive using curl `curl -O https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz`
-2. Extract the archive using `tar -xvf pspdev-ubuntu-latest-x86_64.tar.gz`
-3. To make the toolchain usable, some environment variables need to be set. The first step in doing so it to open the `~/.bashrc` file with the `nano` text editor using the following command from an Ubuntu terminal:
+1. In a fresh WSL Session download the Toolchain Archive using the following command:
+    ```shell
+    wget https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz
+    ```
+3. Extract the archive using:
+    ```shell
+    tar -xvf pspdev-ubuntu-latest-x86_64.tar.gz
+    ```
+5. To make the toolchain usable, some environment variables need to be set. The first step in doing so it to open the `~/.bashrc` file with the `nano` text editor using the following command from an Ubuntu terminal:
     ```shell
     nano ~/.bashrc
     ```
-4. Add the following lines at the bottom of the file in the text editor:
+5. Add the following lines at the bottom of the file in the text editor:
     ```shell
     export PSPDEV="$HOME/pspdev"
     export PATH="$PATH:$PSPDEV/bin"
     ```
-5. Now save and exit by pressing `Ctrl`+`X`, then `Y` and then enter/return.
-6. Close the current Ubuntu terminal and open a new one.
-7. From the new Ubuntu terminal, run the following command to confirm everything is set up correctly:
+6. Now save and exit by pressing `Ctrl`+`X`, then `Y` and then enter/return.
+7. Close the current Ubuntu terminal and open a new one.
+8. From the new Ubuntu terminal, run the following command to confirm everything is set up correctly:
     ```shell
     psp-config --pspdev-path
     ```
+    If everything is set up correctly, the path of the PSPDEV toolchain installation will be shown.
 
 That's it, now the PSPDEV toolchain can be used to build PSP software. Check out the [Basic Programs](../basic_programs.html) page to for examples on what you can do with it.


### PR DESCRIPTION
This is based on an interaction with a user on the Discord, who was not sure if the output of the psp-config command was correct or how to open an Ubunutu terminal in a specific location. This change should address that.

When I tried to do the install on my Windows installation, I also found curl did not download the release, but wget did. So I changed to wget.