### PR TITLE
Do not disable local threads in sprite example

### DIFF
--- a/_includes/samples/sprite/main.c
+++ b/_includes/samples/sprite/main.c
@@ -5,7 +5,6 @@
 #include <memory.h>
 
 #define STB_IMAGE_IMPLEMENTATION
-#define STBI_NO_THREAD_LOCALS
 #include <stb_image.h>
 
 PSP_MODULE_INFO("texture", 0, 1, 0);


### PR DESCRIPTION
This is no longer needed, as not using it no longer causes a crash since we disabled local thread support in gcc.