### PR TITLE
Add link to installation instructions to downloads page

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -7,7 +7,7 @@ nav_order: 6
 # Downloads
 {: .fs-8 .fw-700 .text-center }
 
-To download the latest version of the PSPDEV toolchain click on the link for your system:
+Download the latest update for the PSPDEV toolchain here. If you don't have it setup yet, go to the [installation instructions](installation.html) instead! Otherwise click on the link for your system:
 
 - [Windows/Ubuntu/Debian](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz)
 - [MacOS (arm64)](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-latest-arm64.tar.gz)


### PR DESCRIPTION
I think this was necessary, since it is pretty unclear what to do with the download otherwise.