### PR TITLE
add package index to navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,8 @@ color_scheme: dark
 exclude:
   - README.md
   - Gemfile.lock
+
+nav_external_links:
+  - title: "PSPDEV's package index"
+    url: "https://pspdev.github.io/psp-packages/"
+    opens_in_new_tab: true


### PR DESCRIPTION
Much better to visible in our navigation.

Displayed like this:

![image](https://github.com/user-attachments/assets/601d4f79-0a11-4a45-a86a-9b5144647346)
