### PR TITLE
add pspsdk docs link in the navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ exclude:
   - Gemfile.lock
 
 nav_external_links:
+  - title: "PSPSDK's documentation"
+    url: "https://pspdev.github.io/pspsdk/"
+    opens_in_new_tab: true
   - title: "PSPDEV's package index"
     url: "https://pspdev.github.io/psp-packages/"
     opens_in_new_tab: true


### PR DESCRIPTION
Displayed like this, I'll make a change if desired:

![image](https://github.com/user-attachments/assets/e0695584-c352-4ab7-b239-910ca741582f)

additional from #76 