### PR TITLE
Update documentation.md

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -7,15 +7,11 @@ nav_order: 7
 # Additional Documentation
 {: .fs-8 .fw-700 .text-center }
 
-PSPDEV is made out of several components. Here is a (non-exhaustive) list of
-links to the documentation available for them:
+Here are links to additional community made documentation, mostly on the PSP hardware, which can be helpful for PSPDEV contributors:
 
- - [PSPSDK](https://pspdev.github.io/pspsdk/): The documentation for the
-   developer kit.
  - [PSP Allegrex documentation](https://pspdev.github.io/vfpu-docs/):
    Non-official documentation on the PSP CPU and VFPU.
  - [Unofficial PSP docs](https://uofw.github.io/upspd/docs/): A collection of docs
    from different authors and sources, covering more specific topics.
  - [Yet Another PSP Documentation](http://hitmen.c02.at/files/yapspd/): A very
    detailed hardware documentation, including software interfaces.
-


### PR DESCRIPTION
The link to the PSPSDK documentation is no longer needed. I also clarified what you'll find in the documentation we link to, since they are quite technical and not tutorials.