### PR TITLE
Fix cmake deprecation warning

### DIFF
--- a/_includes/samples/audio/CMakeLists.txt
+++ b/_includes/samples/audio/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(audio)
 

--- a/_includes/samples/controls/CMakeLists.txt
+++ b/_includes/samples/controls/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(controls)
 

--- a/_includes/samples/hello/CMakeLists.txt
+++ b/_includes/samples/hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(hello)
 

--- a/_includes/samples/sdl2/CMakeLists.txt
+++ b/_includes/samples/sdl2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(sdl2)
 

--- a/_includes/samples/sdl2_image/CMakeLists.txt
+++ b/_includes/samples/sdl2_image/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(sdl2-image)
 

--- a/_includes/samples/sdl2_mixer/CMakeLists.txt
+++ b/_includes/samples/sdl2_mixer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(sdl2_mixer)
 

--- a/_includes/samples/sdl2_ttf/CMakeLists.txt
+++ b/_includes/samples/sdl2_ttf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(sdl2_ttf)
 

--- a/_includes/samples/shape/CMakeLists.txt
+++ b/_includes/samples/shape/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(shape)
 

--- a/_includes/samples/sprite/CMakeLists.txt
+++ b/_includes/samples/sprite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(texture)
 


### PR DESCRIPTION
CMake release 3.31 deprecates compatibility with versions of CMake older than 3.10. The release notes states: 'Compatibility with versions of CMake older than 3.10 is now deprecated and will be removed from a future version. Calls to cmake_minimum_required() or cmake_policy() that set the policy version to an older value now issue a deprecation diagnostic.'

https://cmake.org/cmake/help/latest/release/3.31.html#deprecated-and-removed-features

Updating from 3.5 release (2016-03-08) to 3.11 release (2018-03-28) fixes the warning without giving an high constraint to the users because it will work for install 7 years old. Source code will not be blocked to old releases if other upgrades are needed in the future.