### PR TITLE
Add libusb-compat to installed dependencies on MacOS

### DIFF
--- a/installation/macos.md
+++ b/installation/macos.md
@@ -15,7 +15,7 @@ The PSP SDK requires a couple of dependencies to be installed before use. Instal
 Once brew is installed, run the following command from a terminal to install the dependencies:
 
 ```shell
-brew install cmake pkgconf gnu-sed bash openssl libtool libmpc libarchive gettext texinfo bison flex isl gsl gmp mpfr
+brew install cmake pkgconf gnu-sed bash openssl libtool libmpc libarchive gettext texinfo bison flex isl gsl gmp mpfr libusb-compat
 ```
 
 ## PSP SDK 


### PR DESCRIPTION
This makes sure pspsh can be used.