### PR TITLE
Link to MacOS 15 build for x86_64 instead of 13

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -11,7 +11,7 @@ Download the latest update for the PSP SDK here. If you don't have it setup yet,
 
 - [Windows/Ubuntu](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz)
 - [MacOS (arm64)](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-latest-arm64.tar.gz)
-- [MacOS (x86_64)](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-13-x86_64.tar.gz)
+- [MacOS (x86_64)](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-15-intel-x86_64.tar.gz)
 - [Fedora](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-fedora-latest.tar.gz)
 - [Debian](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-debian-latest.tar.gz)
 - [Docker](https://hub.docker.com/r/pspdev/pspdev)

--- a/installation/macos.md
+++ b/installation/macos.md
@@ -25,7 +25,7 @@ Installing the PSP SDK itself can be done with the following steps:
 
 1. Download the latest version of the SDK for your system here:
     - [arm64](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-latest-arm64.tar.gz) for M1 or newer CPUs.
-    - [x86_64](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-13-x86_64.tar.gz) for Intel CPUs.
+    - [x86_64](https://github.com/pspdev/pspdev/releases/latest/download/pspdev-macos-15-intel-x86_64.tar.gz) for Intel CPUs.
 2. Extract the downloaded archive into your home directory, resulting in `/home/YOURUSERNAME/pspdev` being created.
 3. To make the SDK usable, some environment variables need to be set. The first step in doing so it to open the `~/.zprofile` file with the `pico` text editor using the following command from a terminal:
     ```shell


### PR DESCRIPTION
MacOS 13 will soon no longer be available for GitHub Actions, so we should migrate away from it. Once the other PRs are merged related to this, the website should be updated by merging this PR.