### PR TITLE
Include pspuser.h instead of pspkernel in examples

### DIFF
--- a/_includes/samples/audio/main.c
+++ b/_includes/samples/audio/main.c
@@ -1,4 +1,4 @@
-#include <pspkernel.h>
+#include <pspuser.h>
 #include <pspdebug.h>
 #include <pspaudiolib.h>
 #include <pspaudio.h>

--- a/_includes/samples/controls/main.c
+++ b/_includes/samples/controls/main.c
@@ -1,4 +1,4 @@
-#include <pspkernel.h>
+#include <pspuser.h>
 #include <pspdebug.h>
 #include <pspctrl.h>
 #include <stdlib.h>

--- a/_includes/samples/hello/main.c
+++ b/_includes/samples/hello/main.c
@@ -1,4 +1,4 @@
-#include <pspkernel.h>
+#include <pspuser.h>
 #include <pspdebug.h>
 #include <pspdisplay.h>
 

--- a/_includes/samples/shape/main.c
+++ b/_includes/samples/shape/main.c
@@ -1,4 +1,4 @@
-#include <pspkernel.h>
+#include <pspuser.h>
 #include <pspgu.h>
 #include <pspdisplay.h>
 

--- a/_includes/samples/sprite/main.c
+++ b/_includes/samples/sprite/main.c
@@ -1,4 +1,4 @@
-#include <pspkernel.h>
+#include <pspuser.h>
 #include <pspctrl.h>
 #include <pspdisplay.h>
 #include <pspgu.h>


### PR DESCRIPTION
We're planning on phasing out the use of pspkernel.h for regular applications.